### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/setup-go@v5
         with: { go-version: '1.23' }
 
-      - uses: golangci/golangci-lint-action@v6
-        with: { version: v1.64 }
+      - uses: golangci/golangci-lint-action@v8
+        with: { version: v2.2.2 }
   gitfs:
     name: gitfs
     runs-on: ${{ matrix.os }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: 2
 run:
   go: "1.23"
   timeout: 5m


### PR DESCRIPTION
## Summary
- bump golangci-lint binary to v2.2.2
- use golangci/golangci-lint-action v8
- update config for v2 format

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687372a543108332a62c78bba2b47342